### PR TITLE
package.json - Unblock webpack version

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "file-loader": "^0.8.4",
     "vue-loader": "^10.0.2",
     "vue-template-compiler": "^2.1.8",
-    "webpack": "2.1.0-beta.27",
+    "webpack": "^2.1.0-beta.27",
     "webpack-dev-server": "^2.1.0-beta.0"
   }
 }


### PR DESCRIPTION
A recent webpack-dev-server needs a webpack >= 2.2.0  
Otherwise I got a npm ERR peer dep missing... And app refusing to load in the browser with a "not really explicit" `Uncaught TypeError: Cannot read property 'split' of undefined` in some webpack code.  
I guess it could help others, hence this PR.
  
Btw, thanks for this great and simple Apollo / Vue example 👍 